### PR TITLE
Fix version of tap-kit using github commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
         "singer-python==5.2.0",
         'requests==2.18.4',
         "pendulum==1.2.0",
-        "tap-kit==0.1.1"
+        "tap-kit @ git+https://github.com/Radico/tap-kit.git@bc4b936975f679a5887891036570daf1bab01c64"
     ],
     dependency_links=[
-        "https://github.com/Radico/tap-kit/tarball/master#egg=tap-kit-0.1.1",
+        "https://github.com/Radico/tap-kit/tarball/bc4b936975f679a5887891036570daf1bab01c64#egg=tap-kit-0.1.1",
     ],
     entry_points="""
     [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "tap-kit @ git+https://github.com/Radico/tap-kit.git@bc4b936975f679a5887891036570daf1bab01c64"
     ],
     dependency_links=[
-        "https://github.com/Radico/tap-kit/tarball/bc4b936975f679a5887891036570daf1bab01c64#egg=tap-kit-0.1.1",
+        "https://github.com/Radico/tap-kit/tarball/bc4b936975f679a5887891036570daf1bab01c64",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
## Context

It seem that tap-kit v0.1.1 is not available anymore via `pip`:

```bash
$ pip install tap-kit==0.1.1                                                                                                                                                                             
ERROR: Could not find a version that satisfies the requirement tap-kit==0.1.1
ERROR: No matching distribution found for tap-kit==0.1.1
```

Tracking it back in the repo, the version 0.1.1 refers most likely to this [old commit](https://github.com/Radico/tap-kit/tree/bc4b936975f679a5887891036570daf1bab01c64). 

Therefore, since the package is not available anymore via `pip`, this PR fixes the issue by fixing the version using the correct git sha commit.